### PR TITLE
add: token to send with post-signup form for BE route protection

### DIFF
--- a/client/src/pages/postSignup/PostSignup.jsx
+++ b/client/src/pages/postSignup/PostSignup.jsx
@@ -8,6 +8,7 @@ import axios from "axios";
 
 const PostSignup = () => {
   const { id } = useSelector(state => state.user);
+  const { token } = useSelector(state => state.auth);
   const options = ["Online only", "Online & In-person", "In-person only"];
   const dispatch = useDispatch();
   const navigate = useNavigate();
@@ -36,6 +37,7 @@ const PostSignup = () => {
             learning: postData.learning,
             occupation: postData.job,
             location: postData.location,
+            token,
           }
         );
         if (res) {


### PR DESCRIPTION
Token now being passed to BE so will pass backend route protection. But the Post-signup page is still not working correctly, as the id and user data first received back form the DB on clicking past the initial sign up page are not saved into global state, so the post-signup page cannot use those details immedaitely to communicate with the DB. 